### PR TITLE
add -lrt for clock_gettime of tldevel.c

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ AM_LDFLAGS += -Wno-undef
 
 
 
-LIBS =  -lpthread -lm 
+LIBS =  -lpthread -lm -lrt
 
 
 #     AC_SUBST(HDF5_CFLAGS)


### PR DESCRIPTION
When I use the old glibc, kalign does not compile successfully.
So I add '-lrt' to fix this problem:
`undefined reference to clock_gettime `

reference: https://stackoverflow.com/questions/2418157/c-error-undefined-reference-to-clock-gettime-and-clock-settime
