### PR TITLE
Add check for linux-specific constant

### DIFF
--- a/src/tldevel.h
+++ b/src/tldevel.h
@@ -518,8 +518,15 @@ ALLOC_2D_ARRAY_DEF(double);
 
 
 #define DECLARE_TIMER(n) struct timespec ts1_##n; struct timespec ts2_##n;
+
+#ifdef CLOCK_MONOTONIC_RAW
 #define START_TIMER(n) clock_gettime(CLOCK_MONOTONIC_RAW, &ts1_##n);
 #define STOP_TIMER(n) clock_gettime(CLOCK_MONOTONIC_RAW, &ts2_##n);
+#else
+#define START_TIMER(n) gettimeofday(&ts1_##n);
+#define STOP_TIMER(n) gettimeofday(&ts2_##n);
+#endif
+
 #define GET_TIMING(n) (double)(ts2_##n.tv_sec - ts1_##n.tv_sec) + ((double)  ts2_##n.tv_nsec - ts1_##n.tv_nsec) / 1000000000.0
 
 


### PR DESCRIPTION
Apparently `CLOCK_MONOTONIC_RAW` was introduced in Linux 2.6.28 and doesn't exist in OSX. Falling back to `gettimeofday()` in these cases seems to allow kalign to compile in OSX, and a quick test appears successful. I don't know whether this fallback will affect timing on OSX-based systems.