### PR TITLE
Don't discard the provided CFLAGS

### DIFF
--- a/m4/ax_set_compile_flags.m4
+++ b/m4/ax_set_compile_flags.m4
@@ -19,11 +19,11 @@ if test "$enable_debugging" != "no"; then
 AC_DEFINE(DEBUG,1,[Defines debugging .])
 
 ADD_DEBUG_COMPILE_WARNINGS
-CFLAGS="-ggdb -std=gnu11"
+CFLAGS="-ggdb -std=gnu11 ${CFLAGS}"
 CFLAGS="${CFLAGS} ${TLDEVEL_CFLAGS}"
 else
 ADD_PRODUCTION_COMPILE_WARNINGS
-CFLAGS="-O3 -std=gnu11"
+CFLAGS="-O3 -std=gnu11 ${CFLAGS}"
 CFLAGS="${CFLAGS} ${TLDEVEL_CFLAGS}"
 DEBUG=0
 fi


### PR DESCRIPTION
Hello. This is a patch from the Debian package for kalign. It help us (and others) provide additional build flags, such as Debian's default build hardening flags: https://wiki.debian.org/Hardening#Environment_variables