### PR TITLE
Enable building on non-x86 architectures

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: autogen
       run: ./autogen.sh
@@ -29,7 +31,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: install build tools
       run: brew install automake
     - name: autogen

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,11 @@
 name: C/C++ CI
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        submodules: recursive
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/simde"]
+	path = src/simde
+	url = https://github.com/nemequ/simde-no-tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = version.sh autogen.sh VERSION
+EXTRA_DIST = version.sh autogen.sh VERSION src/simde
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/src/alignment.c
+++ b/src/alignment.c
@@ -20,7 +20,8 @@
 
 */
 
-#include <xmmintrin.h>
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse.h>
 #include "alignment.h"
 
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -23,14 +23,12 @@
 #include "tldevel.h"
 #include "tlrng.h"
 
-#ifdef HAVE_AVX2
-#include <immintrin.h>
-#endif
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/avx.h>
 
 #include "misc.h"
 #include  <stdalign.h>
 #include <string.h>
-#include <immintrin.h>
 #ifdef ITEST_MISC
 
 


### PR DESCRIPTION
Hello again. This is a patch from the Debian package for kalign. It enables building kalign on no-x86 systems using the [SIMD Everywhere](https://github.com/simd-everywhere/simde) header only library.