### PR TITLE
Fix for occasional seg fault

### DIFF
--- a/lib/src/msa_op.c
+++ b/lib/src/msa_op.c
@@ -348,13 +348,21 @@ int convert_msa_to_internal(struct msa* msa, int type)
 
         t = a->to_internal;
         msa->L = a->L;
+        int unknown = 0;
+        if (t[(int)'X'] != -1) {
+                unknown = t[(int)'X'];
+        } else if (t[(int)'N'] != -1) {
+                unknown = t[(int)'N'];
+        }
+
         for(i = 0; i <  msa->numseq;i++){
                 seq = msa->sequences[i];
                 for(j =0 ; j < seq->len;j++){
                         if(t[(int) seq->seq[j]] == -1){
                                 WARNING_MSG("there should be no character not matching the alphabet");
-                                WARNING_MSG("offending character: >>>%c<<<", seq->seq[j]);
+                                WARNING_MSG("offending character: >>>%c<<<, replacing internal alphabet value: %d with unknown: %d", seq->seq[j], seq->s[j], unknown);
                                 /* exit(0); */
+                                seq->s[j] = unknown;
                         }else{
                                 seq->s[j] = t[(int) seq->seq[j]];
                         }


### PR DESCRIPTION
This usually happens when 'U' (Selenocysteine) is found in a protein sequence. 
The seg fault only seems to happen when called from the python bindings. Otherwise, it seems that the uninitialized memory is zero when calling the binary directly.

Currently, when a character is found that isn't in the alphabet, a warning is triggered but the loop continues, leaving the uninitialized memory in that array. This is later used in 
`lib/src/bpm.c`:
```
for (int i = 0; i < n+W; i++) {
        /* LOG_MSG(" (%d)",i); */
        uint8_t c = 0;
        if(i >= n){
                /* seq padding  */
                c = 0;
        }else{
                c = (uint8_t)t[i]; <---- Using uninitialized memory as an index
        }
        /* LOG_MSG(" c: %d  (%d)", c,i); */
        int carry = 0;

        for (int b = 0; b <= y; b++) {
                /* LOG_MSG("y: %d c: %d b: %d n: %d m:%d",y, c,b,n,m); */
                uint64_t Pv = P[b];
                uint64_t Mv = M[b];
                uint64_t Eq = Peq[c][b]; <---- Undefined behaviour
```
The fix tries to treat the unknown alphabet letters as ambiguous or it falls back to zeroing the memory. 
