### PR TITLE
docs: add a required version for Zig builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ make install
 **Note**: On macOS, Kalign automatically configures OpenMP with Homebrew's libomp installation at `/opt/homebrew/opt/libomp/`.
 
 #### Alternative Build Systems
+When using `zig`, version `0.12` is required to build this project. 
 
 **Zig Build** (for cross-compilation):
 ```bash


### PR DESCRIPTION
This PR notes that using Zig for compilation requires Zig version to be example `v0.12` as the build system has changed and this `build.zig` does not work with newer Zig versions.