### PR TITLE
cmake: allow overriding hardcoded libomp path on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,15 +75,15 @@ set(KALIGN_KMEANS_UPGMA_THRESHOLD "50" CACHE STRING "Number of sequences thresho
 
 
 if(USE_OPENMP)
-  # Configure OpenMP for macOS with Homebrew (only for arm64 native builds)
-  if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64" AND NOT CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
-    list(APPEND CMAKE_PREFIX_PATH /opt/homebrew)
-    # Set OpenMP flags for Apple Clang + Homebrew libomp
-    set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+  # Configure OpenMP for macOS with external libomp (only for Apple Clang on arm64 native builds)
+  if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64" AND NOT CMAKE_OSX_ARCHITECTURES MATCHES "x86_64" AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+    # Defaults to Homebrew
+    set(LIBOMP_ROOT "/opt/homebrew/opt/libomp" CACHE PATH "libomp install prefix")
+    set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_ROOT}/include")
     set(OpenMP_C_LIB_NAMES "omp")
-    set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+    set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${LIBOMP_ROOT}/include")
     set(OpenMP_CXX_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY /opt/homebrew/opt/libomp/lib/libomp.dylib)
+    set(OpenMP_omp_LIBRARY "${LIBOMP_ROOT}/lib/libomp.dylib")
   endif()
 
   find_package(OpenMP)


### PR DESCRIPTION
Hi! I'm the maintainer of the kalign package in nixpkgs.

While updating the package to 3.5.1, I ran into a macOS build issue caused by a hardcoded libomp path in `CMakeLists.txt`, and wanted to propose a fix upstream.

## Problem

On aarch64-darwin, the build fails outside of a Homebrew environment because the libomp path is hardcoded to `/opt/homebrew`:

```
make[2]: *** No rule to make target '/opt/homebrew/opt/libomp/lib/libomp.dylib', needed by 'lib/libkalign.3.5.1.dylib'.  Stop.
```

In Nix (and other custom build setups), `libomp` lives outside `/opt/homebrew`, so the hardcoded path breaks the build on Apple Silicon. See NixOS/nixpkgs#492312 for the downstream report.

## Changes

- Introduce a `LIBOMP_ROOT` CMake cache variable that defaults to `/opt/homebrew/opt/libomp`, so Homebrew users keep the current behavior while other environments can override it (e.g. `-DLIBOMP_ROOT=/nix/store/.../libomp`).
- Scope the manual OpenMP override to `AppleClang` only. Other compilers (GCC, LLVM Clang) support OpenMP natively and should go through the normal `find_package(OpenMP)` path instead of being forced through the Apple Clang workaround.